### PR TITLE
nginxの静的ファイル配信設定を最適化

### DIFF
--- a/webapp/etc/nginx/conf.d/default.conf
+++ b/webapp/etc/nginx/conf.d/default.conf
@@ -4,6 +4,17 @@ server {
   client_max_body_size 10m;
   root /public/;
 
+  # CSSファイルの配信をnginxで行う
+  location /css/ {
+    root /public/;
+  }
+
+  # JavaScriptファイルの配信をnginxで行う
+  location /js/ {
+    root /public/;
+  }
+
+  # アプリケーションのプロキシ
   location / {
     proxy_set_header Host $host;
     proxy_pass http://app:8080;


### PR DESCRIPTION
scoreは1165点から1225点に増加。
スコア改善策としては、データベースのチューニング、キャッシュの活用、リバースプロキシの導入が挙げられる。
変更の手間が最も小さいため、まずリバースプロキシの適用を検討した。
元の設定では Nginx が静的コンテンツを配信していなかったため、改訂版では UI の静的ファイルを Nginx から配信するように修正した。
